### PR TITLE
fix: broken cinemark logo

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@
             </div>
         </nav>
         <nav class="shop-options">
-            <img class="logo" src="../images/cinemark_logo.png" />
+            <img class="logo" src="../resources/images/cinemark_logo.png" />
             <nav class="options">
                 <h3>Billboard</h3>
                 <h3>Theaters</h3>


### PR DESCRIPTION
#### 🤔 Why?

- Fix broken cinemark logo.

#### 🛠 What I changed:

- pages/index.html

#### 🚦 Functional Testing Results:
- Frontend:
![image](https://github.com/HaroldR23/cinema/assets/107003395/15e04b3d-baae-4f4a-b16d-e6bd328f5ea4)
